### PR TITLE
Enable syntax highlighting for adblocker syntax

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,3 @@
 [attr]adb   linguist-detectable linguist-language=AdBlock
 # change if too broad
 *.txt adb
-hosts linguist-detectable linguist-language=hosts

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+[attr]adb   linguist-detectable linguist-language=AdBlock
+# change if too broad
+*.txt adb
+hosts linguist-detectable linguist-language=hosts


### PR DESCRIPTION
GitHub can show syntax highlighting on filterlists:
![image](https://github.com/Daxy7/webSiteFilters/assets/84232764/4239c2b5-daef-4018-8211-5e7d7e62b634)
This PR enables it.
[HOSTs files also can have syntax highlighting, which I have enabled.](https://github.com/StevenBlack/hosts/pull/2352).
Edit: HOSTs file highlighting is broken, so undoing that
Thanks
